### PR TITLE
slider joint bug fixed

### DIFF
--- a/Descriptor/core/parser.py
+++ b/Descriptor/core/parser.py
@@ -400,13 +400,16 @@ class Configurator:
             if 'RigidJointMotion' in joint_type:
                 pass
             else:
-                
-                joint_vector = joint.jointMotion.rotationAxisVector.asArray() 
+                # SiderJoint also does not have rotation axis
+                if 'SliderJointMotion' in joint_type:
+                    joint_vector=joint.jointMotion.slideDirectionVector.asArray()
+                    joint_limit_max = joint.jointMotion.slideLimits.maximumValue
+                    joint_limit_min = joint.jointMotion.slideLimits.minimumValue
+                else:
+                    joint_vector = joint.jointMotion.rotationAxisVector.asArray() 
+                    joint_limit_max = joint.jointMotion.rotationLimits.maximumValue
+                    joint_limit_min = joint.jointMotion.rotationLimits.minimumValue
 
-                joint_rot_val = joint.jointMotion.rotationValue
-                joint_limit_max = joint.jointMotion.rotationLimits.maximumValue
-                joint_limit_min = joint.jointMotion.rotationLimits.minimumValue
-                
                 if abs(joint_limit_max - joint_limit_min) == 0:
                     joint_limit_min = -3.14159
                     joint_limit_max = 3.14159


### PR DESCRIPTION
I think we missed the slider joint because it does not belong to the demo scenes. 
https://github.com/cadop/fusion360descriptor/issues/43
I found the proper property name for the slider joint. 
It works for me with a mixed joint structure. 

 