### PR TITLE
Add Fusion script manifest file

### DIFF
--- a/Descriptor/Descriptor.manifest
+++ b/Descriptor/Descriptor.manifest
@@ -1,0 +1,10 @@
+{
+	"autodeskProduct":	"Fusion360",
+	"type":	"script",
+	"author":	"syuntoku14, yanshil, cadop, apric0ts, simjeh",
+	"description":	{
+		"":	"Export stl and URDF file for ROS project"
+	},
+	"supportedOS":	"windows|mac",
+	"editEnabled":	true
+}


### PR DESCRIPTION
This file is expected by Fusion to avoid the "Failed to read the python script" error as detailed in #28. This should get the script to work out of the box since the appropriate `.vscode` folder and `.env` file should be automatically generated or are unique to each user system.

I added all the contributors that I could find in the code and that had contributed to this repository, but feel free to amend if I made any errors.